### PR TITLE
Broken xsi schema location

### DIFF
--- a/Documentation and Samples/_Examples_/sample_dispatchnotification_opentrans_2_1.xml
+++ b/Documentation and Samples/_Examples_/sample_dispatchnotification_opentrans_2_1.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<DISPATCHNOTIFICATION version="2.1" xmlns="http://www.opentrans.org/XMLSchema/2.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opentrans.org/XMLSchema/2.1 opentrans_2_1.xsd" xmlns:bmecat="http://www.bmecat.org/bmecat/2005" xmlns:xmime="http://www.w3.org/2005/05/xmlmime">
+<DISPATCHNOTIFICATION version="2.1" xmlns="http://www.opentrans.org/XMLSchema/2.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opentrans.org/XMLSchema/2.1/opentrans_2_1.xsd" xmlns:bmecat="http://www.bmecat.org/bmecat/2005" xmlns:xmime="http://www.w3.org/2005/05/xmlmime">
 	<DISPATCHNOTIFICATION_HEADER>
 		<CONTROL_INFO>
 			<GENERATION_DATE>2009-05-13T06:20:00+01:00</GENERATION_DATE>
@@ -45,9 +45,9 @@
 					<ADDRESS>
 						<bmecat:NAME>Customer Corp..</bmecat:NAME>
 						<CONTACT_DETAILS>
-							<bmecat:CONTACT_ID>GüntherD</bmecat:CONTACT_ID>
+							<bmecat:CONTACT_ID>GÃ¼ntherD</bmecat:CONTACT_ID>
 							<bmecat:CONTACT_NAME>Doe</bmecat:CONTACT_NAME>
-							<bmecat:FIRST_NAME>Günther</bmecat:FIRST_NAME>
+							<bmecat:FIRST_NAME>GÃ¼nther</bmecat:FIRST_NAME>
 						</CONTACT_DETAILS>
 						<bmecat:STATE>Hamburg</bmecat:STATE>
 						<bmecat:COUNTRY>Germany</bmecat:COUNTRY>
@@ -66,7 +66,7 @@
 						<bmecat:STREET>incstreet 102</bmecat:STREET>
 						<bmecat:ZIP>70199</bmecat:ZIP>
 						<bmecat:CITY>Stuttgart</bmecat:CITY>
-						<bmecat:STATE>Baden Württemberg</bmecat:STATE>
+						<bmecat:STATE>Baden WÃ¼rttemberg</bmecat:STATE>
 					</ADDRESS>
 				</PARTY>
 			</PARTIES>

--- a/Documentation and Samples/_Examples_/sample_invoice_opentrans_2_1.xml
+++ b/Documentation and Samples/_Examples_/sample_invoice_opentrans_2_1.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<INVOICE version="2.1" xmlns="http://www.opentrans.org/XMLSchema/2.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opentrans.org/XMLSchema/2.1 opentrans_2_1.xsd" xmlns:bmecat="http://www.bmecat.org/bmecat/2005" xmlns:xmime="http://www.w3.org/2005/05/xmlmime">
+<INVOICE version="2.1" xmlns="http://www.opentrans.org/XMLSchema/2.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opentrans.org/XMLSchema/2.1/opentrans_2_1.xsd" xmlns:bmecat="http://www.bmecat.org/bmecat/2005" xmlns:xmime="http://www.w3.org/2005/05/xmlmime">
 	<INVOICE_HEADER>
 		<CONTROL_INFO>
 			<GENERATION_DATE>2009-05-13T06:20:00+01:00</GENERATION_DATE>
@@ -60,7 +60,7 @@
 						<bmecat:STREET>shopppingstr.102</bmecat:STREET>
 						<bmecat:ZIP>70199</bmecat:ZIP>
 						<bmecat:CITY>Stuttgart</bmecat:CITY>
-						<bmecat:STATE>Baden Württemberg</bmecat:STATE>
+						<bmecat:STATE>Baden WÃ¼rttemberg</bmecat:STATE>
 					</ADDRESS>
 				</PARTY>
 				<PARTY>
@@ -75,7 +75,7 @@
 			<INVOICE_ISSUER_IDREF type="supplier_specific">108304</INVOICE_ISSUER_IDREF>
 			<INVOICE_RECIPIENT_IDREF type="supplier_specific">968314</INVOICE_RECIPIENT_IDREF>
 			<bmecat:CURRENCY>EUR</bmecat:CURRENCY>
-			<TERMS_AND_CONDITIONS>Können unter www.supershopstore.com/agb abgerufen werden</TERMS_AND_CONDITIONS>
+			<TERMS_AND_CONDITIONS>KÃ¶nnen unter www.supershopstore.com/agb abgerufen werden</TERMS_AND_CONDITIONS>
 			<E_BILLING>
 				<SIGNATURE_AND_VERIFICATION>
 					<SIGNATURE>
@@ -125,7 +125,7 @@
 					<bmecat:FNAME>Gewicht</bmecat:FNAME>
 					<bmecat:FVALUE>1</bmecat:FVALUE>
 					<bmecat:FUNIT>KG</bmecat:FUNIT>
-					<bmecat:FDESCR>Das Gewicht wird standardmäßig ohne Akku angegeben.</bmecat:FDESCR>
+					<bmecat:FDESCR>Das Gewicht wird standardmÃ¤ÃŸig ohne Akku angegeben.</bmecat:FDESCR>
 				</FEATURE>
 			</PRODUCT_FEATURES>
 			<PRODUCT_COMPONENTS>

--- a/Documentation and Samples/_Examples_/sample_invoice_opentrans_2_1_xml signature.xml
+++ b/Documentation and Samples/_Examples_/sample_invoice_opentrans_2_1_xml signature.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<INVOICE version="2.1" xmlns="http://www.opentrans.org/XMLSchema/2.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opentrans.org/XMLSchema/2.1 opentrans_2_1.xsd" xmlns:bmecat="http://www.bmecat.org/bmecat/2005" xmlns:xmime="http://www.w3.org/2005/05/xmlmime" xmlns:xsig="http://www.w3.org/2000/09/xmldsig#">
+<INVOICE version="2.1" xmlns="http://www.opentrans.org/XMLSchema/2.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opentrans.org/XMLSchema/2.1/opentrans_2_1.xsd" xmlns:bmecat="http://www.bmecat.org/bmecat/2005" xmlns:xmime="http://www.w3.org/2005/05/xmlmime" xmlns:xsig="http://www.w3.org/2000/09/xmldsig#">
 	<INVOICE_HEADER>
 		<CONTROL_INFO>
 			<GENERATION_DATE>2009-05-13T06:20:00+01:00</GENERATION_DATE>
@@ -60,7 +60,7 @@
 						<bmecat:STREET>shopppingstr.102</bmecat:STREET>
 						<bmecat:ZIP>70199</bmecat:ZIP>
 						<bmecat:CITY>Stuttgart</bmecat:CITY>
-						<bmecat:STATE>Baden Württemberg</bmecat:STATE>
+						<bmecat:STATE>Baden WÃ¼rttemberg</bmecat:STATE>
 					</ADDRESS>
 				</PARTY>
 				<PARTY>
@@ -75,7 +75,7 @@
 			<INVOICE_ISSUER_IDREF type="supplier_specific">108304</INVOICE_ISSUER_IDREF>
 			<INVOICE_RECIPIENT_IDREF type="supplier_specific">968314</INVOICE_RECIPIENT_IDREF>
 			<bmecat:CURRENCY>EUR</bmecat:CURRENCY>
-			<TERMS_AND_CONDITIONS>Können unter www.supershopstore.com/agb abgerufen werden</TERMS_AND_CONDITIONS>
+			<TERMS_AND_CONDITIONS>KÃ¶nnen unter www.supershopstore.com/agb abgerufen werden</TERMS_AND_CONDITIONS>
 			<E_BILLING>
 				<SIGNATURE_AND_VERIFICATION>
 					<SIGNATURE>
@@ -141,7 +141,7 @@
 					<bmecat:FNAME>Gewicht</bmecat:FNAME>
 					<bmecat:FVALUE>1</bmecat:FVALUE>
 					<bmecat:FUNIT>KG</bmecat:FUNIT>
-					<bmecat:FDESCR>Das Gewicht wird standardmäßig ohne Akku angegeben.</bmecat:FDESCR>
+					<bmecat:FDESCR>Das Gewicht wird standardmÃ¤ÃŸig ohne Akku angegeben.</bmecat:FDESCR>
 				</FEATURE>
 			</PRODUCT_FEATURES>
 			<PRODUCT_COMPONENTS>

--- a/Documentation and Samples/_Examples_/sample_invoicelist_credit_card_statement_opentrans_2_1.xml
+++ b/Documentation and Samples/_Examples_/sample_invoicelist_credit_card_statement_opentrans_2_1.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<INVOICELIST version="2.1" xsi:schemaLocation="http://www.opentrans.org/XMLSchema/2.1 opentrans_2_1.xsd" xmlns="http://www.opentrans.org/XMLSchema/2.1" xmlns:bmecat="http://www.bmecat.org/bmecat/2005" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<INVOICELIST version="2.1" xsi:schemaLocation="http://www.opentrans.org/XMLSchema/2.1/opentrans_2_1.xsd" xmlns="http://www.opentrans.org/XMLSchema/2.1" xmlns:bmecat="http://www.bmecat.org/bmecat/2005" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<INVOICELIST_HEADER>
 		<INVOICELIST_INFO>
 			<INVOICELIST_ID>CCS-392</INVOICELIST_ID>

--- a/Documentation and Samples/_Examples_/sample_order_opentrans_2_1_xml signature.xml
+++ b/Documentation and Samples/_Examples_/sample_order_opentrans_2_1_xml signature.xml
@@ -8,7 +8,7 @@ Not all possible elements are shown here. If multi-language support is required,
 
 Please note that only dummy-prices and units are used. No price-calculations were made at the time of creation.
  -->
-<ORDER type="standard" version="2.1" xmlns="http://www.opentrans.org/XMLSchema/2.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opentrans.org/XMLSchema/2.1 opentrans_2_1.xsd" xmlns:bmecat="http://www.bmecat.org/bmecat/2005" xmlns:xmime="http://www.w3.org/2005/05/xmlmime" xmlns:xsig="http://www.w3.org/2000/09/xmldsig#">
+<ORDER type="standard" version="2.1" xmlns="http://www.opentrans.org/XMLSchema/2.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opentrans.org/XMLSchema/2.1/opentrans_2_1.xsd" xmlns:bmecat="http://www.bmecat.org/bmecat/2005" xmlns:xmime="http://www.w3.org/2005/05/xmlmime" xmlns:xsig="http://www.w3.org/2000/09/xmldsig#">
 	<ORDER_HEADER>
 		<CONTROL_INFO>
 			<GENERATION_DATE>2009-05-13T06:20:00+01:00</GENERATION_DATE>


### PR DESCRIPTION
The examples display an error in the implementation for the xsi:schemaLocation reference. The reference points to an invalid xsd due to a whitespace, which should have been a slash. 

Adopting the implementation based on a broken example causes the implementer to waste time trying to understand why the document does not validate.