### PR TITLE
Some minor improvements for REMARK and CONTROL_INFO

### DIFF
--- a/OpenTrans.net/BaseReader.cs
+++ b/OpenTrans.net/BaseReader.cs
@@ -87,7 +87,8 @@ namespace OpenTrans.net
                     Remark remark = new Remark
                     {
                         Value = XmlUtils.NodeAsString(remarkNode, ".", nsmgr),
-                        Type = XmlUtils.AttributeText(remarkNode, "type")
+                        Type = XmlUtils.AttributeText(remarkNode, "type"),
+                        Lang = XmlUtils.AttributeText(remarkNode, "lang")
                     };
                     item.Remarks.Add(remark);
                 }

--- a/OpenTrans.net/OrderReader.cs
+++ b/OpenTrans.net/OrderReader.cs
@@ -139,7 +139,8 @@ namespace OpenTrans.net
                         Remark remark = new Remark
                         {
                             Value = XmlUtils.NodeAsString(remarkNode, ".", nsmgr),
-                            Type = XmlUtils.AttributeText(remarkNode, "type")
+                            Type = XmlUtils.AttributeText(remarkNode, "type"),
+                            Lang = XmlUtils.AttributeText(remarkNode, "lang")
                         };
                         order.Remarks.Add(remark);
                     }

--- a/OpenTrans.net/OrderWriter.cs
+++ b/OpenTrans.net/OrderWriter.cs
@@ -60,8 +60,8 @@ namespace OpenTrans.net
 
             Writer.WriteStartElement("ORDER_HEADER");
             Writer.WriteStartElement("CONTROL_INFO");
-            _writeDateTime(Writer, "GENERATION_DATE", DateTime.Now);
             _writeOptionalElementString(Writer, "GENERATOR_INFO", generatorInfo);
+            _writeDateTime(Writer, "GENERATION_DATE", DateTime.Now);
             Writer.WriteEndElement(); // !CONTROL_INFO
             Writer.WriteStartElement("SOURCING_INFO");
             Writer.WriteEndElement(); // !SOURCING_INFO

--- a/OpenTrans.net/Remark.cs
+++ b/OpenTrans.net/Remark.cs
@@ -20,29 +20,26 @@
 namespace OpenTrans.net
 {
     /// <summary>
-    /// This element contains the notes for a business document. 
-    /// VALUE has to be specified, else the remark will be ignored.
+    /// This element contains remarks related to a business document. The remark is identified with the
+    /// attribute "type" for use in different business documents. It is only permissible to identify remarks
+    /// for use in this or the following business documents using the attribute "type".
     /// </summary>
     public class Remark
     {
         /// <summary>
-        /// The remark itself
+        /// The remark itself.
         /// </summary>
         public string Value { get; set; }
 
         /// <summary>
-        /// The type of the remark. Custom types are allowed.
-        ///
-        /// List of predefined types:
-        /// deliverynote, dispatchnotification, general, invoice,
-        /// order, orderchange, orderresponse, quotation,
-        /// receiptacknowledgement, remittanceadvice, invoicelist,
-        /// rfqrfq, transport
+        /// Specifies the type of remark. The remark is identified for use in a variety of business
+        /// documents. The business partner processing the document which matches the attribute evaluates
+        /// the information contained, otherwise the information is passed on along the process chain.
         /// </summary>
         public string Type { get; set; }
         
         /// <summary>
-        /// The language used for the remark
+        /// Specifies the used language for the remark.
         /// </summary>
         public string Lang { get; set; }
     }


### PR DESCRIPTION
Hi Stephan,

I had a few more minor changes on my hand for a while now. They are already in use in some of my projects, which is why I probably forgot to create a pull request. So here they are:

- The order reader is now able to read the defined language for a remark.
- Old remark summaries have been replaced with the original OpenTrans definitions.
- The generation date element within the control info section will now be rendered at its correct position.

Also I wanted to ask you, if it would be possible to publish to NuGet after merging the pull request?

Thanks a lot and best,
Jan