### PR TITLE
Datetime parsing with timezones

### DIFF
--- a/OpenTrans.net/BaseReader.cs
+++ b/OpenTrans.net/BaseReader.cs
@@ -31,39 +31,20 @@ namespace OpenTrans.net
         protected DateTime? _nodeAsDateTime(XmlNode node, string xpath, XmlNamespaceManager nsmgr = null)
         {
             string _temp = XmlUtils.NodeAsString(node, xpath, nsmgr);
+            DateTime retval;
 
-            if (_temp.Length == 8)
+            try 
             {
-                if (DateTime.TryParseExact(_temp, "yyyyMMdd", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime retval))
-                {
-                    return retval;
-                }
+                retval = XmlConvert.ToDateTime(_temp, XmlDateTimeSerializationMode.RoundtripKind);
+                return retval;
+            } catch (FormatException) 
+            {
             }
-            else if (_temp.Length == 10)
-            {
-                if (DateTime.TryParseExact(_temp, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime retval))
-                {
-                    return retval;
-                }
-            }
-            else if ((_temp.Length > 20) && (_temp.Contains("+")))
-            {
 
-                if (DateTimeOffset.TryParse(_temp, out DateTimeOffset retval))
-                {
-                    return retval.UtcDateTime;
-                }
-            }
-            else
+            // for compatibility
+            if (DateTime.TryParseExact(_temp, "yyyyMMdd", CultureInfo.InvariantCulture, DateTimeStyles.None, out retval))
             {
-                if (DateTime.TryParseExact(_temp, "yyyy-MM-ddTHH:mm:sszzz", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime retval))
-                {
-                    return retval;
-                }
-                if (DateTime.TryParseExact(_temp, "yyyy-MM-ddTHH:mm:ss", CultureInfo.InvariantCulture, DateTimeStyles.None, out retval))
-                {
-                    return retval;
-                }
+                return retval;
             }
 
             return null;

--- a/OpenTrans.net/OrderResponse.cs
+++ b/OpenTrans.net/OrderResponse.cs
@@ -48,6 +48,11 @@ namespace OpenTrans.net
         public DateTime? OrderDate { get; set; }
 
         /// <summary>
+        /// Date of the order response - required field
+        /// </summary>
+        public DateTime? OrderResponseDate { get; set; }
+
+        /// <summary>
         /// The alteration sequence is increased by one with the dispatch of each ORDERCHANGE
         /// business document.The numbering begins at 1.
         /// </summary>

--- a/OpenTrans.net/OrderResponseReader.cs
+++ b/OpenTrans.net/OrderResponseReader.cs
@@ -65,6 +65,7 @@ namespace OpenTrans.net
                 retval.OrderId = XmlUtils.NodeAsString(headerNode, "./*[local-name()='ORDERRESPONSE_INFO']/*[local-name()='ORDER_ID']", nsmgr);
                 retval.SupplierOrderId = XmlUtils.NodeAsString(headerNode, "./*[local-name()='ORDERRESPONSE_INFO']/*[local-name()='SUPPLIER_ORDER_ID']", nsmgr);
                 retval.OrderDate = _nodeAsDateTime(headerNode, "./*[local-name()='ORDERRESPONSE_INFO']/*[local-name()='ORDER_DATE']", nsmgr);
+                retval.OrderResponseDate = _nodeAsDateTime(headerNode, "./*[local-name()='ORDERRESPONSE_INFO']/*[local-name()='ORDERRESPONSE_DATE']", nsmgr);
                 retval.OrderChangeSequenceId = XmlUtils.NodeAsInt(headerNode, "./*[local-name()='ORDERRESPONSE_INFO']/*[local-name()='ORDERCHANGE_SEQUENCE_ID']", nsmgr);
 
                 XmlNodeList partyNodes = headerNode.SelectNodes(".//*[local-name()='PARTIES']/*[local-name()='PARTY']", nsmgr);

--- a/OpenTrans.net/OrderResponseWriter.cs
+++ b/OpenTrans.net/OrderResponseWriter.cs
@@ -78,7 +78,7 @@ namespace OpenTrans.net
                 Writer.WriteElementString("SUPPLIER_ORDER_ID", orderResponse.OrderId);
             }
             
-            _writeDateTime(Writer, "ORDERRESPONSE_DATE", DateTime.Now);
+            _writeDateTime(Writer, "ORDERRESPONSE_DATE", orderResponse.OrderResponseDate ?? DateTime.Now);
             if (orderResponse.OrderDate.HasValue)
             {
                 _writeDateTime(Writer, "ORDER_DATE", orderResponse.OrderDate.Value);


### PR DESCRIPTION
1. read timezone information by using `XmlConvert.ToDateTime(...)` instead of `DateTime.ParseExact`
2. added `OrderResponse.OrderResonseDate` which was missing